### PR TITLE
表紙画像を挿入するスクリプトを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ brew install ghostscript
 brew install xpdf
 ```
 
+表紙画像を本文 PDF `book/output/ebook.pdf` に挿入する。ただし、表紙画像は `book/cover/cover.png` に限ります。表紙画像を挿入した PDF は `book/output/ebook_covered.pdf` に保存されます。
+
+```shell
+yarn cover
+```
+
 ## サポートするスクリプト
 
 | コマンド | 内容 |
@@ -129,3 +135,4 @@ brew install xpdf
 | `yarn press` | プレス版の pdf を生成（`make press` 相当）|
 | `yarn open` | pdf を開く（`make open` 相当）|
 | `yarn clean` | 生成ファイルをすべて削除（`make clean` 相当）|
+| `yarn cover` | 表紙画像を本文 PDF に挿入する |

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "pdf": "cd ./book/ && vivliostyle build",
     "press": "cd ./book/ && vivliostyle build --preflight press-ready-local --preflight-option gray-scale --style ./theme/theme-press.css --output ./output/press.pdf",
     "open": "open ./book/output/ebook.pdf",
-    "clean": "rm -rf ./book/output/"
+    "clean": "rm -rf ./book/output/",
+    "cover": "node ./scripts/InsertCoverImage.js"
   },
   "devDependencies": {
     "@vivliostyle/cli": "^8.17.1",
     "npm-run-all2": "^7.0.1",
+    "pdf-lib": "^1.17.1",
     "textlint": "^14.4.0",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-preset-ja-spacing": "^2.3.0",

--- a/scripts/InsertCoverImage.js
+++ b/scripts/InsertCoverImage.js
@@ -53,20 +53,17 @@ const insertImageAsFirstPage = async () => {
         throw new Error("Unsupported image format. Use PNG or JPG.");
       })();
 
-  // 新しいページを作成 (ページサイズを指定)
-  const newPage = pdfDoc.addPage([pageWidth, pageHeight]);
+  // 新しいページを最初のページに作成する (ページサイズを指定)
+  const newPage = pdfDoc.insertPage(0, [pageWidth, pageHeight]);
 
-  // 画像をページ全体にスケーリングして描画
+  // 画像をページ全体にスケーリングして描画する
   newPage.drawImage(embeddedImage, {
     x: 0,
     y: 0,
     width: pageWidth,
     height: pageHeight,
   });
-
-  // 挿入した新しいページを先頭に移動
-  pdfDoc.insertPage(0, newPage);
-
+  
   // PDFを保存
   const newPdfBytes = await pdfDoc.save();
   fs.writeFileSync(outputPath, newPdfBytes);

--- a/scripts/InsertCoverImage.js
+++ b/scripts/InsertCoverImage.js
@@ -1,5 +1,5 @@
-import fs from "fs";
-import { PDFDocument } from "pdf-lib";
+const fs = require("fs");
+const { PDFDocument } = require("pdf-lib");
 
 /**
  * 本文 PDF に表紙画像を挿入するスクリプト
@@ -72,12 +72,7 @@ const insertImageAsFirstPage = async () => {
   fs.writeFileSync(outputPath, newPdfBytes);
 };
 
-
 // 表紙画像を挿入する
-try {
-  console.log(`It inserts cover image "${imagePath}" into "${pdfPath}".`);
-  await insertImageAsFirstPage()
-  console.log(`It succeeded to insert cover image and save to "${outputPath}".`);
-} catch (error) {
-  console.warn(error)
-}
+insertImageAsFirstPage().catch(err => {
+  console.warn(err.message);
+});

--- a/scripts/InsertCoverImage.js
+++ b/scripts/InsertCoverImage.js
@@ -1,0 +1,83 @@
+import fs from "fs";
+import { PDFDocument } from "pdf-lib";
+
+/**
+ * 本文 PDF に表紙画像を挿入するスクリプト
+ * 
+ * 本文 PDF の `book/output/ebook.pdf` と表紙画像の `book/cover/cover.png` が存在する時、
+ * 表紙画像を挿入した PDF `book/output/ebook_covered.pdf` を生成します。
+ * 
+ * 表紙画像は本文と製作タイミングが異なる、手動で挿入したい場合も想定できるので、任意機能です。
+ * 
+ */
+
+// 本文 PDF のパス（入力）
+const pdfPath = "book/output/ebook.pdf";
+
+// 表紙画像 のパス（入力）
+const imagePath = "book/cover/cover.png";
+
+// 表紙画像を挿入した後の PDF のパス（出力）
+const outputPath = "book/output/ebook_covered.pdf";
+
+// A5 のサイズ
+const pageWidth = 419.53;
+const pageHeight = 595.25;
+
+/**
+ * PDF に表紙画像を挿入する
+ */
+const insertImageAsFirstPage = async () => {
+
+  // ファイルの存在を確認する
+  if (!fs.existsSync(pdfPath)) {
+    throw new Error(`PDF file "${pdfPath}" does not exist.`);
+  }
+  if (!fs.existsSync(imagePath)) {
+    throw new Error(`Image file "${imagePath}" does not exist.`);
+  }
+
+  // PDFを読み込む
+  const pdfBytes = fs.readFileSync(pdfPath);
+  const pdfDoc = await PDFDocument.load(pdfBytes);
+
+  // 画像を読み込む
+  const imageBytes = fs.readFileSync(imagePath);
+
+  // 画像を埋め込む (PNG/JPEGを自動判別)
+  const embeddedImage = imagePath.endsWith(".png")
+    ? await pdfDoc.embedPng(imageBytes)
+    : imagePath.endsWith(".jpg") || imagePath.endsWith(".jpeg")
+    ? await pdfDoc.embedJpg(imageBytes)
+    : (() => {
+        throw new Error("Unsupported image format. Use PNG or JPG.");
+      })();
+
+  // 新しいページを作成 (ページサイズを指定)
+  const newPage = pdfDoc.addPage([pageWidth, pageHeight]);
+
+  // 画像をページ全体にスケーリングして描画
+  newPage.drawImage(embeddedImage, {
+    x: 0,
+    y: 0,
+    width: pageWidth,
+    height: pageHeight,
+  });
+
+  // 挿入した新しいページを先頭に移動
+  pdfDoc.insertPage(0, newPage);
+
+  // PDFを保存
+  const newPdfBytes = await pdfDoc.save();
+  fs.writeFileSync(outputPath, newPdfBytes);
+};
+
+
+// 表紙画像を挿入する
+try {
+  console.log(`It inserts cover image "${imagePath}" into "${pdfPath}".`);
+  await insertImageAsFirstPage()
+  console.log(`It succeeded to insert cover image and save to "${outputPath}".`);
+} catch (error) {
+  console.warn(error)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5841,7 +5841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdf-lib@npm:^1.16.0":
+"pdf-lib@npm:^1.16.0, pdf-lib@npm:^1.17.1":
   version: 1.17.1
   resolution: "pdf-lib@npm:1.17.1"
   dependencies:
@@ -7269,6 +7269,7 @@ __metadata:
   dependencies:
     "@vivliostyle/cli": "npm:^8.17.1"
     npm-run-all2: "npm:^7.0.1"
+    pdf-lib: "npm:^1.17.1"
     textlint: "npm:^14.4.0"
     textlint-filter-rule-comments: "npm:^1.2.2"
     textlint-rule-preset-ja-spacing: "npm:^2.3.0"


### PR DESCRIPTION
## やったこと

本文 PDF に表紙画像を追加するスクリプトを追加した

## やってないこと

- リリースのアクションに表紙画像を追加したPDFを添付する
- 他、cover/* をリリースのアセットに追加する
